### PR TITLE
ci: Add GitHub Actions based CI for build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
     - name: List installed Python packages
       run: python -m pip list
 
+    - name: Cleanup to have dist build be as clean as possible
+      run: |
+        cd subdir
+        rm -rf src/example_pkg/_version.py
+        rm -rf build
+
     - name: Build a sdist and wheel
       run: |
         cd subdir
@@ -52,9 +58,9 @@ jobs:
     - name: List contents of sdist
       run: |
         cd subdir
-        python -m tarfile --list dist/pyhf-*.tar.gz
+        python -m tarfile --list dist/example-pkg-*.tar.gz
 
     - name: List contents of wheel
       run: |
         cd subdir
-        python -m zipfile --list dist/pyhf-*.whl
+        python -m zipfile --list dist/example_pkg-*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         rm -rf build
 
     - name: Build a sdist and wheel
+      continue-on-error: true
       run: |
         cd subdir
         pipx run build .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.x']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Local install
+      run: |
+        python -m pip install --upgrade pip wheel
+        cd subdir
+        python -m pip install --upgrade .
+
+    - name: List installed Python packages
+      run: python -m pip list
+
+    - name: Build a sdist and wheel
+      run: |
+        cd subdir
+        pipx run build .
+
+    - name: Verify the distribution
+      run: |
+        cd subdir
+        pipx run twine check --strict dist/*
+
+    - name: List contents of sdist
+      run: |
+        cd subdir
+        python -m tarfile --list dist/pyhf-*.tar.gz
+
+    - name: List contents of wheel
+      run: |
+        cd subdir
+        python -m zipfile --list dist/pyhf-*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel
         cd subdir
-        python -m pip install --upgrade .
+        python -m pip install .
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
         python-version: ['3.x']
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -45,8 +48,8 @@ jobs:
         rm -rf src/example_pkg/_version.py
         rm -rf build
 
+      # c.f. https://github.com/scikit-build/scikit-build-core/issues/495
     - name: Build a sdist and wheel
-      continue-on-error: true
       run: |
         cd subdir
         pipx run build .


### PR DESCRIPTION
Provide automatic testing for the problems described in https://github.com/scikit-build/scikit-build-core/issues/495.

```
* Add CI to verify build procedure and automate consistency checks.
```