### PR TITLE
fix: Get subdirectory based packge builds working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     - name: List contents of sdist
       run: |
         cd subdir
-        python -m tarfile --list dist/example-pkg-*.tar.gz
+        python -m tarfile --list dist/example_pkg-*.tar.gz
 
     - name: List contents of wheel
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
     - name: Build a sdist and wheel
       run: |
         cd subdir
-        # pipx run build .
         python -m pip install --upgrade build
         python -m build .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
     - name: Build a sdist and wheel
       run: |
         cd subdir
-        pipx run build .
+        # pipx run build .
+        python -m pip install --upgrade build
+        python -m build .
 
     - name: Verify the distribution
       run: |

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
+# required by setuptools-scm even if it's empty
+[tool.setuptools_scm]
+
 [[tool.scikit-build.generate]]
 path = "example_pkg/_version.py"
 template = '''

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -24,17 +24,13 @@ dependencies = [
 ]
 
 [tool.scikit-build]
-minimum-version = "0.4"
-build-dir = "build/{wheel_tag}"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["src/example_pkg/_version.py"]
 
-[tool.setuptools_scm]
-local_scheme = "no-local-version"
-# Need to give root as we aren't at the same level as the git repo
-root = ".."
-# Need to provide path relative to root
-write_to = "subdir/src/example_pkg/_version.py"
+[[tool.scikit-build.generate]]
+path = "example_pkg/_version.py"
+template = '''
+version = "${version}"
+'''
 
 # https://github.com/pypa/setuptools_scm/blob/5b1c77b71ebf66413f3ecfea2222b5b3e0a26bcd/docs/config.md?plain=1#L30
 # recommends modern versions like:

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -29,6 +29,7 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 # required by setuptools-scm even if it's empty
 [tool.setuptools_scm]
+root = ".."
 
 [[tool.scikit-build.generate]]
 path = "example_pkg/_version.py"

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "scikit-build-core>=0.5.1",
-  "pybind11>=2.10.3"
+  "scikit-build-core>=0.5.0",
+  "pybind11>=2.10.0"
   ]
 build-backend = "scikit_build_core.build"
 

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "scikit-build-core>=0.5.1",
   "pybind11>=2.10.3",
-  "setuptools-scm>=7.1.0"
+  "setuptools-scm>=7.1.0,<8.0.0"
   ]
 build-backend = "scikit_build_core.build"
 

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
   "scikit-build-core",
   "pybind11",
+  "setuptools-scm"
   ]
 build-backend = "scikit_build_core.build"
 

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
+# Ignore the commit hash in version
+local_scheme = "no-local-version"
 # Need to give root as we aren't at the same level as the git repo
 root = ".."
 

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -37,11 +37,3 @@ path = "example_pkg/_version.py"
 template = '''
 version = "${version}"
 '''
-
-# https://github.com/pypa/setuptools_scm/blob/5b1c77b71ebf66413f3ecfea2222b5b3e0a26bcd/docs/config.md?plain=1#L30
-# recommends modern versions like:
-#
-# relative_to = ".."
-# version_file = "subdir/src/example_pkg/_version.py"
-#
-# but doesn't seem to have succes

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-  "scikit-build-core",
-  "pybind11",
-  "setuptools-scm"
+  "scikit-build-core>=0.5.1",
+  "pybind11>=2.10.3",
+  "setuptools-scm>=7.1.0"
   ]
 build-backend = "scikit_build_core.build"
 

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
-# required by setuptools-scm even if it's empty
 [tool.setuptools_scm]
+# Need to give root as we aren't at the same level as the git repo
 root = ".."
 
 [[tool.scikit-build.generate]]

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "scikit-build-core>=0.5.1",
   "pybind11>=2.10.3",
-  "setuptools-scm>=7.1.0,<8.0.0"
+  "setuptools-scm>=7.1.0"
   ]
 build-backend = "scikit_build_core.build"
 

--- a/subdir/pyproject.toml
+++ b/subdir/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
   "scikit-build-core>=0.5.1",
-  "pybind11>=2.10.3",
-  "setuptools-scm>=7.1.0"
+  "pybind11>=2.10.3"
   ]
 build-backend = "scikit_build_core.build"
 

--- a/subdir/src/example_pkg/__init__.py
+++ b/subdir/src/example_pkg/__init__.py
@@ -1,1 +1,7 @@
 from example_pkg._version import version as __version__
+
+__all__ = ["__version__"]
+
+
+def __dir__():
+    return __all__

--- a/subdir/src/example_pkg/__init__.py
+++ b/subdir/src/example_pkg/__init__.py
@@ -1,0 +1,1 @@
+from example_pkg._version import version as __version__


### PR DESCRIPTION
Implimentations of suggestions from https://github.com/scikit-build/scikit-build-core/issues/495.

cc @henryiii for follow up


```
* Use scikit-build.generate to write package version information along with
  tool.setuptools_scm options to provide path to root directory of Git repo.
* Fix typo with sdist pacakge name.
* Use pip install of build to avoid CPython version error with pipx.
* Add import of version information as __version__ to allow example_pkg.__version__ API.

Co-authored-by: Henry Schreiner <HenrySchreinerIII@gmail.com>
Co-authored-by: Cristian Le <cristian.le@mpsd.mpg.de>
```